### PR TITLE
Add date sorting order to the RSS feed

### DIFF
--- a/scripts/gen-rss.js
+++ b/scripts/gen-rss.js
@@ -11,7 +11,7 @@ async function generate() {
   })
 
   const posts = await fs.readdir(path.join(__dirname, '..', 'pages', 'posts'))
-
+  const allPosts = []
   await Promise.all(
     posts.map(async (name) => {
       if (name.startsWith('index.')) return
@@ -21,7 +21,7 @@ async function generate() {
       )
       const frontmatter = matter(content)
 
-      feed.item({
+      allPosts.push({
         title: frontmatter.data.title,
         url: '/posts/' + name.replace(/\.mdx?/, ''),
         date: frontmatter.data.date,
@@ -32,6 +32,10 @@ async function generate() {
     })
   )
 
+  allPosts.sort((a, b) => new Date(b.date) - new Date(a.date))
+  allPosts.forEach((post) => {
+      feed.item(post)
+  })
   await fs.writeFile('./public/feed.xml', feed.xml({ indent: true }))
 }
 


### PR DESCRIPTION
Prior to this change, I noticed that my RSS feed was out of order and just going based on file name. This didn't seem ideal for when someone was trying to pull the RSS feed.

You can see the end result of this change here - https://rishigoomar.com/feed.xml